### PR TITLE
Use 'defaults' instead of 'syntax' to register for scopes.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,12 +16,15 @@
 from SublimeLinter.lint import Linter, util
 
 
-class GLSLLint(Linter):
+class GlslangValidator(Linter):
 
     """Provides an interface to glslangValidator."""
 
-    syntax = ('glsl', 'essl')
     cmd = ('glslangValidator', '@')
+    multiline = False
+    defaults = {
+        'selector': 'source.glsl, source.essl'
+    }
     regex = (r'^ERROR:\s.*:(?P<line>\d+):\s\'(?P<near>.*)\'\s:\s+(?P<message>.+)')
     error_stream = util.STREAM_BOTH
     tempfile_suffix = '-'


### PR DESCRIPTION
Hi,

this linter isn't compatible with SublimeLinter anymore. The error message gives instructions on how to fix it so it's pretty easy to get it working again.
Would be great if you could accept the pull request and push an update to PackageControl.